### PR TITLE
Let children projects override `:aliases`

### DIFF
--- a/dev-resources/t_parent/samples/children/with_parent_with_aliases/project.clj
+++ b/dev-resources/t_parent/samples/children/with_parent_with_aliases/project.clj
@@ -1,0 +1,5 @@
+(defproject child-with-parent-with-aliases "0.0.1"
+  :description "Child project that references parent project with aliases"
+  :parent-project {:path    "../../parents/with_aliases/project.clj"
+                   :inherit [:aliases]}
+  :aliases {"my-alias" ["child"]})

--- a/dev-resources/t_parent/samples/parents/with_aliases/project.clj
+++ b/dev-resources/t_parent/samples/parents/with_aliases/project.clj
@@ -1,0 +1,4 @@
+(defproject lein-parent/parent-with-aliases "0.0.1"
+  :description "Parent project that provides aliases to be inherited"
+  :aliases {"my-alias"   ["parent"]
+            "my-alias-2" ["parent"]})

--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,5 @@
   :eval-in-leiningen true
   :plugins [[lein-midje "3.2.1"]]
   :profiles {:dev {:dependencies [[midje "1.9.8"]
+                                  [fipp "0.6.24"] ;; solve a conflict
                                   [com.cemerick/pomegranate "1.1.0"]]}})

--- a/src/lein_parent/plugin.clj
+++ b/src/lein_parent/plugin.clj
@@ -6,6 +6,18 @@
 
 (defn middleware [project]
   (if-let [inherited (parent/inherited-properties project)]
-    (with-meta (meta-merge project inherited)
-               (update (meta project) :profiles merge (:profiles inherited)))
+    (let [[left-base right-base] (map (fn [m]
+                                        (dissoc m :aliases))
+                                      [project inherited])
+          [left-aliases right-aliases] (map (fn [m]
+                                              (select-keys m [:aliases]))
+                                            [project inherited])
+          ;; all properties except `:aliases` are merged left-to-right (`inherited` takes precedence),
+          ;; since that is lein-parent's traditional behavior:
+          merged-bases (meta-merge left-base right-base)
+          ;; `:aliases` are merged right-to-left (`project` takes precedence):
+          merged-aliases (meta-merge right-aliases left-aliases)
+          merged (merge merged-bases merged-aliases)]
+      (with-meta merged
+        (update (meta project) :profiles merge (:profiles inherited))))
     project))

--- a/test/leiningen/t_parent.clj
+++ b/test/leiningen/t_parent.clj
@@ -89,4 +89,10 @@
       ;; with-profiles calls the set-profiles function to 'activate' selected profiles
       (let [project (read-child-project "with_parent_with_profile")]
         (is (nil? (:bar project)))
-        (is (= "bar" (get-in project [:profiles :foo :bar])))))))
+        (is (= "bar" (get-in project [:profiles :foo :bar]))))))
+
+  (testing "child has higher priority in merges"
+    (let [project (read-child-project "with_parent_with_aliases")]
+      (is (= {"my-alias"   ["child"]
+              "my-alias-2" ["parent"]}
+             (select-keys (:aliases project) ["my-alias" "my-alias-2"]))))))


### PR DESCRIPTION
All other behavior has been kept as-is, i.e. there isn't a generalized change in precedence order.

The included test passes:

<img width="980" alt="image" src="https://user-images.githubusercontent.com/1162994/165673641-b811d32d-eda2-4e82-bf0e-77fbc235a06f.png">
