### PR TITLE
Support `:local-repo` option

### DIFF
--- a/src/leiningen/parent.clj
+++ b/src/leiningen/parent.clj
@@ -61,12 +61,13 @@
     (project/init-project (project/read file))))
 
 (defn resolve-project-from-coords
-  [coords {:keys [repositories offline? update checksum]}]
+  [coords {:keys [repositories offline? update checksum local-repo]}]
   (let [resolved-parent-artifact (first (aether/resolve-artifacts
                                           :coordinates [coords]
                                           :repositories (map (comp (partial update-policies update checksum) classpath/add-repo-auth)
                                                              repositories)
-                                          :offline? offline?))
+                                          :offline? offline?
+                                          :local-repo local-repo))
         artifact-jar (:file (meta resolved-parent-artifact))
         artifact-zip (ZipFile. artifact-jar)
         project-clj-path (format "META-INF/leiningen/%s/project.clj" (first coords))]


### PR DESCRIPTION
Reference:

https://github.com/technomancy/leiningen/blob/24fb93936133bd7fc30c393c127e9e69bb5f2392/sample.project.clj#L144-L145

This allows using an isolated `.m2` dir, which helps with Docker stuff.

I verified locally that it works as intended.